### PR TITLE
zero encoder offset

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -71,14 +71,14 @@ public final class Constants {
             public static final int STEER_MOTOR_ID = 2;
             public static final int DRIVE_MOTOR_ID = 3;
             public static final int ENCODER_ID = 4;
-            public static final double ENCODER_OFFSET_RADIANS = -Math.toRadians(176); 
+            public static final double ENCODER_OFFSET_RADIANS = 0;// -Math.toRadians(176); 
             public static final int STATES_INDEX = 0;        }
 
         public static final class FrontRightSwerveConstants {
             public static final int STEER_MOTOR_ID = 5;
             public static final int DRIVE_MOTOR_ID = 6;
             public static final int ENCODER_ID = 7;
-            public static final double ENCODER_OFFSET_RADIANS = -Math.toRadians(177.2);
+            public static final double ENCODER_OFFSET_RADIANS =0;//  -Math.toRadians(177.2);
             public static final int STATES_INDEX = 1;
         }
 
@@ -86,7 +86,7 @@ public final class Constants {
             public static final int STEER_MOTOR_ID = 8;
             public static final int DRIVE_MOTOR_ID = 9;
             public static final int ENCODER_ID = 10;
-            public static final double ENCODER_OFFSET_RADIANS = -Math.toRadians(275.8); 
+            public static final double ENCODER_OFFSET_RADIANS = 0;// -Math.toRadians(275.8); 
             public static final int STATES_INDEX = 2;
         }
 
@@ -94,7 +94,7 @@ public final class Constants {
             public static final int STEER_MOTOR_ID = 11;
             public static final int DRIVE_MOTOR_ID = 12;
             public static final int ENCODER_ID = 13;
-            public static final double ENCODER_OFFSET_RADIANS =  -Math.toRadians(315.6);
+            public static final double ENCODER_OFFSET_RADIANS = 0;//  -Math.toRadians(315.6);
             public static final int STATES_INDEX = 3;
         }
 


### PR DESCRIPTION
Zero the encoder offsets, when we configure the drivetrain the first deployed code to the rio should have 0 offsets to allow us to calculate the actual offsets